### PR TITLE
Drop direct babel dependency + allowing dynamicImport, objectRestSpread

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -29,6 +29,17 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "djfarly",
+      "name": "Jan Willem Henckel",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/5230863?v=4",
+      "profile": "https://jan.cologne",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ],
   "repoType": "github"

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,9 +11,9 @@ never done that before, that's great! Check this free short video tutorial to
 learn how: http://kcd.im/pull-request
 -->
 
-* `babel-plugin-codegen` version:
-* `node` version:
-* `npm` (or `yarn`) version:
+- `babel-plugin-codegen` version:
+- `node` version:
+- `npm` (or `yarn`) version:
 
 Relevant code or config
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,9 +34,9 @@ merge of your pull request!
 
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
-* [ ] Documentation
-* [ ] Tests
-* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
-* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
+- [ ] Documentation
+- [ ] Tests
+- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
 
 <!-- feel free to add additional comments -->

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .opt-in
 .opt-out
 .DS_Store
+.eslintcache
 
 # these cause more harm than good
 # when working with contributors

--- a/README.md
+++ b/README.md
@@ -89,14 +89,12 @@ Important notes:
 
 1.  All code run by `codegen` is _not_ run in a sandboxed environment
 2.  All code _must_ run synchronously.
-3.  All code will be transpiled via the same instance of babel, which this
-    plugin is called with. Therefore it should follow all of the normal rules
-    for `.babelrc` resolution (the closest `.babelrc` to the file being run is
-    the one that's used). This means you can rely on any babel
-    plugins/transforms that you're used to using elsewhere in your codebase.
-4.  The code that's generated may or may not be transpiled (babel plugin
-    ordering is tricky business). **You should generate the code that you wish
-    to ship.**
+3.  All code will be transpiled via the same instance of babel this plugin is
+    called with, thus inheriting all presets and plugins. This means you can
+    rely on any babel plugins/transforms that you're used to using elsewhere in
+    your codebase.
+4.  The code that's generated might be transpiled. Please check the output to
+    make sure. (babel plugin ordering is tricky business 😇)
 
 ### Template Tag
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![version][version-badge]][package] [![downloads][downloads-badge]][npmcharts]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs] [![Code of Conduct][coc-badge]][coc]
 [![Babel Macro](https://img.shields.io/badge/babel--macro-%F0%9F%8E%A3-f5da55.svg?style=flat-square)](https://github.com/kentcdodds/babel-plugin-macros)
 
@@ -281,8 +281,8 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 
 <!-- prettier-ignore -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=kentcdodds "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1958812?v=4" width="100px;"/><br /><sub><b>Michael Rawlings</b></sub>](https://github.com/mlrawlings)<br />[💻](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=mlrawlings "Code") [📖](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=mlrawlings "Documentation") [⚠️](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=mlrawlings "Tests") |
-| :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=kentcdodds "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1958812?v=4" width="100px;"/><br /><sub><b>Michael Rawlings</b></sub>](https://github.com/mlrawlings)<br />[💻](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=mlrawlings "Code") [📖](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=mlrawlings "Documentation") [⚠️](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=mlrawlings "Tests") | [<img src="https://avatars3.githubusercontent.com/u/5230863?v=4" width="100px;"/><br /><sub><b>Jan Willem Henckel</b></sub>](https://jan.cologne)<br />[💻](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=djfarly "Code") [📖](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=djfarly "Documentation") [⚠️](https://github.com/kentcdodds/babel-plugin-codegen/commits?author=djfarly "Tests") |
+| :---: | :---: | :---: |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,11 @@
 
 [![Build Status][build-badge]][build]
 [![Code Coverage][coverage-badge]][coverage]
-[![version][version-badge]][package]
-[![downloads][downloads-badge]][npmcharts]
+[![version][version-badge]][package] [![downloads][downloads-badge]][npmcharts]
 [![MIT License][license-badge]][license]
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
-[![PRs Welcome][prs-badge]][prs]
-[![Code of Conduct][coc-badge]][coc]
+[![PRs Welcome][prs-badge]][prs] [![Code of Conduct][coc-badge]][coc]
 [![Babel Macro](https://img.shields.io/badge/babel--macro-%F0%9F%8E%A3-f5da55.svg?style=flat-square)](https://github.com/kentcdodds/babel-plugin-macros)
 
 [![Watch on GitHub][github-watch-badge]][github-watch]
@@ -30,7 +28,9 @@ maintain the exports in my source file. So someone created a post-build script
 to concatenate them to the end of the file. I built this plugin so I could do
 that without having an ad-hoc post-build script.
 
-> Read ["Make maintainable workarounds with codegen 💥"](https://blog.kentcdodds.com/make-maintainable-workarounds-with-codegen-d34163a09c13) for more inspiration
+> Read
+> ["Make maintainable workarounds with codegen 💥"](https://blog.kentcdodds.com/make-maintainable-workarounds-with-codegen-d34163a09c13)
+> for more inspiration
 
 ## This solution
 
@@ -49,23 +49,23 @@ and swaps your usage node with the new AST node.
 
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Template Tag](#template-tag)
-  * [import comment](#import-comment)
-  * [codegen.require](#codegenrequire)
-  * [codegen file comment (`// @codegen`)](#codegen-file-comment--codegen)
-* [Configure with Babel](#configure-with-babel)
-  * [Via `.babelrc` (Recommended)](#via-babelrc-recommended)
-  * [Via CLI](#via-cli)
-  * [Via Node API](#via-node-api)
-* [Use with `babel-plugin-macros`](#use-with-babel-plugin-macros)
-  * [APIs not supported by the macro](#apis-not-supported-by-the-macro)
-* [Caveats](#caveats)
-* [Inspiration](#inspiration)
-* [Other Solutions](#other-solutions)
-* [Contributors](#contributors)
-* [LICENSE](#license)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Template Tag](#template-tag)
+  - [import comment](#import-comment)
+  - [codegen.require](#codegenrequire)
+  - [codegen file comment (`// @codegen`)](#codegen-file-comment--codegen)
+- [Configure with Babel](#configure-with-babel)
+  - [Via `.babelrc` (Recommended)](#via-babelrc-recommended)
+  - [Via CLI](#via-cli)
+  - [Via Node API](#via-node-api)
+- [Use with `babel-plugin-macros`](#use-with-babel-plugin-macros)
+  - [APIs not supported by the macro](#apis-not-supported-by-the-macro)
+- [Caveats](#caveats)
+- [Inspiration](#inspiration)
+- [Other Solutions](#other-solutions)
+- [Contributors](#contributors)
+- [LICENSE](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -89,13 +89,14 @@ Important notes:
 
 1.  All code run by `codegen` is _not_ run in a sandboxed environment
 2.  All code _must_ run synchronously.
-3.  All code will be transpiled via `@babel/core` directly or `@babel/register`
-    and should follow all of the normal rules for `.babelrc` resolution (the
-    closest `.babelrc` to the file being run is the one that's used). This means
-    you can rely on any babel plugins/transforms that you're used to using
-    elsewhere in your codebase.
-4.  The code that's generated may or may not be transpiled (babel plugin ordering
-    is tricky business). **You should generate the code that you wish to ship.**
+3.  All code will be transpiled via the same instance of babel, which this
+    plugin is called with. Therefore it should follow all of the normal rules
+    for `.babelrc` resolution (the closest `.babelrc` to the file being run is
+    the one that's used). This means you can rely on any babel
+    plugins/transforms that you're used to using elsewhere in your codebase.
+4.  The code that's generated may or may not be transpiled (babel plugin
+    ordering is tricky business). **You should generate the code that you wish
+    to ship.**
 
 ### Template Tag
 
@@ -153,7 +154,8 @@ export a function which accepts those arguments and returns a string.
 import /* codegen(3) */ './assign-identity'
 ```
 
-**After** (`assign-identity.js` is: `module.exports = input => 'var x = ' + JSON.stringify(input) + ';'`):
+**After** (`assign-identity.js` is:
+`module.exports = input => 'var x = ' + JSON.stringify(input) + ';'`):
 
 ```javascript
 var x = 3
@@ -167,7 +169,8 @@ var x = 3
 const x = codegen.require('./es6-identity', 3)
 ```
 
-**After** (`es6-identity.js` is: `export default input => 'var x = ' + JSON.stringify(input) + ';'`):
+**After** (`es6-identity.js` is:
+`export default input => 'var x = ' + JSON.stringify(input) + ';'`):
 
 ```javascript
 const x = 3
@@ -175,9 +178,11 @@ const x = 3
 
 ### codegen file comment (`// @codegen`)
 
-Using the codegen file comment will update a whole file to be evaluated down to an export.
+Using the codegen file comment will update a whole file to be evaluated down to
+an export.
 
-Whereas the above usages (assignment/import/require) will only codegen the scope of the assignment or file being imported.
+Whereas the above usages (assignment/import/require) will only codegen the scope
+of the assignment or file being imported.
 
 **Before**:
 
@@ -225,9 +230,10 @@ require('babel-core').transform('code', {
 
 ## Use with `babel-plugin-macros`
 
-Once you've [configured `babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md)
-you can import/require the codegen macro at `babel-plugin-codegen/macro`.
-For example:
+Once you've
+[configured `babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md)
+you can import/require the codegen macro at `babel-plugin-codegen/macro`. For
+example:
 
 ```javascript
 import codegen from 'babel-plugin-codegen/macro'
@@ -243,10 +249,11 @@ export const c = "c";
 
 ### APIs not supported by the macro
 
-* [file comment (`// @codegen`)](#codegen-file-comment--codegen)
-* [import comment](#import-comment)
+- [file comment (`// @codegen`)](#codegen-file-comment--codegen)
+- [import comment](#import-comment)
 
-> You could also use [`codegen.macro`][codegen.macro] if you'd prefer to type less 😀
+> You could also use [`codegen.macro`][codegen.macro] if you'd prefer to type
+> less 😀
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Important notes:
 
 1.  All code run by `codegen` is _not_ run in a sandboxed environment
 2.  All code _must_ run synchronously.
-3.  All code will be transpiled via `babel-core` directly or `babel-register`
+3.  All code will be transpiled via `@babel/core` directly or `@babel/register`
     and should follow all of the normal rules for `.babelrc` resolution (the
     closest `.babelrc` to the file being run is the one that's used). This means
     you can rely on any babel plugins/transforms that you're used to using

--- a/other/CODE_OF_CONDUCT.md
+++ b/other/CODE_OF_CONDUCT.md
@@ -6,12 +6,12 @@
 
 **Table of Contents**
 
-* [Our Pledge](#our-pledge)
-* [Our Standards](#our-standards)
-* [Our Responsibilities](#our-responsibilities)
-* [Scope](#scope)
-* [Enforcement](#enforcement)
-* [Attribution](#attribution)
+- [Our Pledge](#our-pledge)
+- [Our Standards](#our-standards)
+- [Our Responsibilities](#our-responsibilities)
+- [Scope](#scope)
+- [Enforcement](#enforcement)
+- [Attribution](#attribution)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -29,21 +29,21 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
   advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities

--- a/other/MAINTAINING.md
+++ b/other/MAINTAINING.md
@@ -6,11 +6,11 @@
 
 **Table of Contents**
 
-* [Code of Conduct](#code-of-conduct)
-* [Issues](#issues)
-* [Pull Requests](#pull-requests)
-* [Release](#release)
-* [Thanks!](#thanks)
+- [Code of Conduct](#code-of-conduct)
+- [Issues](#issues)
+- [Pull Requests](#pull-requests)
+- [Release](#release)
+- [Thanks!](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "validate": "kcd-scripts validate",
     "precommit": "kcd-scripts precommit"
   },
-  "files": ["dist", "macro.js"],
+  "files": [
+    "dist",
+    "macro.js"
+  ],
   "keywords": [
     "babel-plugin-macros",
     "babel-plugin",
@@ -40,7 +43,11 @@
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js"
   },
-  "eslintIgnore": ["node_modules", "coverage", "dist"],
+  "eslintIgnore": [
+    "node_modules",
+    "coverage",
+    "dist"
+  ],
   "babel": {
     "presets": "kcd-scripts/babel"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-macros": "^2.2.0",
+    "babel-plugin-macros": "^2.2.1",
     "require-from-string": "^2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.0.0-beta.49",
-    "@babel/register": "^7.0.0-beta.49",
     "babel-plugin-macros": "^2.2.0",
     "require-from-string": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "validate": "kcd-scripts validate",
     "precommit": "kcd-scripts precommit"
   },
-  "files": [
-    "dist",
-    "macro.js"
-  ],
+  "files": ["dist", "macro.js"],
   "keywords": [
     "babel-plugin-macros",
     "babel-plugin",
@@ -29,10 +26,10 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.26.3",
-    "babel-plugin-macros": "^2.2.1",
-    "babel-register": "^6.26.0",
-    "babel-template": "^6.26.0",
+    "@babel/core": "^7.0.0-beta.49",
+    "@babel/register": "^7.0.0-beta.49",
+    "@babel/template": "^7.0.0-beta.49",
+    "babel-plugin-macros": "^2.2.0",
     "require-from-string": "^2.0.2"
   },
   "devDependencies": {
@@ -43,11 +40,7 @@
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js"
   },
-  "eslintIgnore": [
-    "node_modules",
-    "coverage",
-    "dist"
-  ],
+  "eslintIgnore": ["node_modules", "coverage", "dist"],
   "babel": {
     "presets": "kcd-scripts/babel"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@babel/core": "^7.0.0-beta.49",
     "@babel/register": "^7.0.0-beta.49",
-    "@babel/template": "^7.0.0-beta.49",
     "babel-plugin-macros": "^2.2.0",
     "require-from-string": "^2.0.2"
   },

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -199,7 +199,7 @@ const x = codegen.require("./fixtures/return-one", "should not be here...")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-Error: <PROJECT_ROOT>/src/__tests__/index.js: \`codegen.require\`-ed module (./fixtures/return-one) cannot accept arguments because it does not export a function. You passed the arguments: should not be here...
+Error: <PROJECT_ROOT>/src/__tests__/index.js: codegen module (src/__tests__/fixtures/return-one) cannot accept arguments because it does not export a function. You passed the arguments: should not be here...
 
 `;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -253,17 +253,6 @@ var fNum: number = do {
 
 `;
 
-exports[`codegen dynamicImport works without passed parserOpts: dynamicImport works without passed parserOpts 1`] = `
-
-// @codegen
-module.exports = "import('./guy').then(() => 'yeah!');"
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import('./guy').then(() => 'yeah!');
-
-`;
-
 exports[`codegen handles multipe nodes: handles multipe nodes 1`] = `
 
 codegen.require('./fixtures/multiple-nodes')
@@ -325,31 +314,6 @@ console.log(foo()); /**
 function foo() {
   return 'foo';
 }
-
-`;
-
-exports[`codegen jsx works without passed parserOpts: jsx works without passed parserOpts 1`] = `
-
-// @codegen
-module.exports = "var jsxElement = <A b={1} />;"
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-var jsxElement = <A b={1} />;
-
-`;
-
-exports[`codegen objectRestSpread works without passed parserOpts: objectRestSpread works without passed parserOpts 1`] = `
-
-// @codegen
-module.exports = "var spreadedObj = { b, ...c };"
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-var spreadedObj = {
-  b,
-  ...c
-};
 
 `;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -236,6 +236,34 @@ ALLCAPS = 'ALLCAPS', void 0;
 
 `;
 
+exports[`codegen accepts babels parser options for generated code: accepts babels parser options for generated code 1`] = `
+
+// @codegen
+module.exports = "var fNum: number = do { if(true) {100} else {200} };"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var fNum: number = do {
+  if (true) {
+    100;
+  } else {
+    200;
+  }
+};
+
+`;
+
+exports[`codegen dynamicImport works without passed parserOpts: dynamicImport works without passed parserOpts 1`] = `
+
+// @codegen
+module.exports = "import('./guy').then(() => 'yeah!');"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import('./guy').then(() => 'yeah!');
+
+`;
+
 exports[`codegen handles multipe nodes: handles multipe nodes 1`] = `
 
 codegen.require('./fixtures/multiple-nodes')
@@ -297,6 +325,31 @@ console.log(foo()); /**
 function foo() {
   return 'foo';
 }
+
+`;
+
+exports[`codegen jsx works without passed parserOpts: jsx works without passed parserOpts 1`] = `
+
+// @codegen
+module.exports = "var jsxElement = <A b={1} />;"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var jsxElement = <A b={1} />;
+
+`;
+
+exports[`codegen objectRestSpread works without passed parserOpts: objectRestSpread works without passed parserOpts 1`] = `
+
+// @codegen
+module.exports = "var spreadedObj = { b, ...c };"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var spreadedObj = {
+  b,
+  ...c
+};
 
 `;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -225,6 +225,17 @@ var two = "2";
 
 `;
 
+exports[`codegen 27. codegen: 27. codegen 1`] = `
+
+codegen\`module.exports = "var ALLCAPS = 'ALLCAPS'"\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var ALLCAPS;
+ALLCAPS = 'ALLCAPS', void 0;
+
+`;
+
 exports[`codegen handles multipe nodes: handles multipe nodes 1`] = `
 
 codegen.require('./fixtures/multiple-nodes')

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -134,5 +134,33 @@ pluginTester({
         \\\`
       \`
     `,
+    'accepts babels parser options for generated code': {
+      babelOptions: {
+        filename: __filename,
+        parserOpts: {plugins: ['flow', 'doExpressions']},
+      },
+      code: `
+        // @codegen
+        module.exports = "var fNum: number = do { if(true) {100} else {200} };"
+      `,
+    },
+    'jsx works without passed parserOpts': {
+      code: `
+        // @codegen
+        module.exports = "var jsxElement = <A b={1} />;"
+      `,
+    },
+    'objectRestSpread works without passed parserOpts': {
+      code: `
+        // @codegen
+        module.exports = "var spreadedObj = { b, ...c };"
+      `,
+    },
+    'dynamicImport works without passed parserOpts': {
+      code: `
+        // @codegen
+        module.exports = "import('./guy').then(() => 'yeah!');"
+      `,
+    },
   },
 })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -89,6 +89,7 @@ pluginTester({
         // @codegen
         /* comment */`,
     },
+    'codegen`module.exports = "var ALLCAPS = \'ALLCAPS\'"`',
   ],
 })
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -144,23 +144,5 @@ pluginTester({
         module.exports = "var fNum: number = do { if(true) {100} else {200} };"
       `,
     },
-    'jsx works without passed parserOpts': {
-      code: `
-        // @codegen
-        module.exports = "var jsxElement = <A b={1} />;"
-      `,
-    },
-    'objectRestSpread works without passed parserOpts': {
-      code: `
-        // @codegen
-        module.exports = "var spreadedObj = { b, ...c };"
-      `,
-    },
-    'dynamicImport works without passed parserOpts': {
-      code: `
-        // @codegen
-        module.exports = "import('./guy').then(() => 'yeah!');"
-      `,
-    },
   },
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -68,19 +68,11 @@ function codeToAST({code, parserOpts = {}}, babel) {
   if (typeof code !== 'string') {
     throw new Error('codegen: Must module.exports a string.')
   }
-  const parserPlugins = (parserOpts && parserOpts.plugins) || []
   return babel.template(code, {
     preserveComments: true,
     placeholderPattern: false,
     ...parserOpts,
     sourceType: 'module',
-    plugins: [
-      // at least enable a minimum set of plugins
-      'jsx',
-      'dynamicImport',
-      'objectRestSpread',
-      ...parserPlugins,
-    ],
   })()
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -61,17 +61,13 @@ function getReplacement({code, fileOpts, args = []}, babel) {
   /**
    * Convert whatever we got now (hopefully a string) into AST form
    */
-  return codeToAST({code: module, parserOpts: fileOpts.parserOpts}, babel)
-}
-
-function codeToAST({code, parserOpts = {}}, babel) {
-  if (typeof code !== 'string') {
+  if (typeof module !== 'string') {
     throw new Error('codegen: Must module.exports a string.')
   }
-  return babel.template(code, {
+  return babel.template(module, {
     preserveComments: true,
     placeholderPattern: false,
-    ...parserOpts,
+    ...fileOpts.parserOpts,
     sourceType: 'module',
   })()
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 const p = require('path')
-const babel = require('babel-core')
-const template = require('babel-template')
+const babel = require('@babel/core')
+const template = require('@babel/template').default
 // const printAST = require('ast-pretty-print')
 const requireFromString = require('require-from-string')
 
@@ -29,9 +29,12 @@ function stringToAST(string) {
   return template(string, {
     sourceType: 'module',
     preserveComments: true,
+    placeholderPattern: false,
     plugins: [
-      // add more on request...
+      // add more on request..
       'jsx',
+      'dynamicImport',
+      'objectRestSpread',
     ],
   })()
 }
@@ -63,7 +66,7 @@ function resolveModuleToString({args, filename, source}) {
   const absolutePath = p.join(p.dirname(filename), source.node.value)
   try {
     // allow for transpilation of required modules
-    require('babel-register')
+    require('@babel/register')
   } catch (e) {
     // ignore error
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -62,14 +62,14 @@ function getReplacement({code, filename, args = []}, babel) {
 
 function stringToAST(string, babel) {
   if (typeof string !== 'string') {
-    throw new Error(`codegen: Must module.exports a string.`)
+    throw new Error('codegen: Must module.exports a string.')
   }
   return babel.template(string, {
     sourceType: 'module',
     preserveComments: true,
     placeholderPattern: false,
     plugins: [
-      // add more on request..
+      // add more on request...
       'jsx',
       'dynamicImport',
       'objectRestSpread',

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function codegenPlugin(babel) {
         path,
         {
           file: {
-            opts: {filename},
+            opts: {filename, parserOpts},
           },
         },
       ) {
@@ -22,27 +22,27 @@ function codegenPlugin(babel) {
 
         if (isCodegen) {
           comments.find(isCodegenComment).value = ' this file was codegened'
-          asProgram(path, filename)
+          asProgram(path, filename, parserOpts)
         }
       },
       Identifier(
         path,
         {
           file: {
-            opts: {filename},
+            opts: {filename, parserOpts},
           },
         },
       ) {
         const isCodegen = path.node.name === 'codegen'
         if (isCodegen) {
-          asIdentifier(path, filename)
+          asIdentifier(path, filename, parserOpts)
         }
       },
       ImportDeclaration(
         path,
         {
           file: {
-            opts: {filename},
+            opts: {filename, parserOpts},
           },
         },
       ) {
@@ -56,7 +56,7 @@ function codegenPlugin(babel) {
           },
         })
         if (isCodegen) {
-          asImportDeclaration(path, filename)
+          asImportDeclaration(path, filename, parserOpts)
         }
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
-const {asProgram, asIdentifier, asImportDeclaration} = require('./replace')
+const getReplacers = require('./replace')
 const {isCodegenComment, looksLike} = require('./helpers')
 
 module.exports = codegenPlugin
 
-function codegenPlugin({transformFromAst}) {
+function codegenPlugin(babel) {
+  const {asProgram, asIdentifier, asImportDeclaration} = getReplacers(babel)
   return {
     name: 'codegen',
     visitor: {
@@ -21,7 +22,7 @@ function codegenPlugin({transformFromAst}) {
 
         if (isCodegen) {
           comments.find(isCodegenComment).value = ' this file was codegened'
-          asProgram(transformFromAst, path, filename)
+          asProgram(path, filename)
         }
       },
       Identifier(

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,7 @@ function codegenPlugin(babel) {
       Program(
         path,
         {
-          file: {
-            opts: {filename, parserOpts},
-          },
+          file: {opts: fileOpts},
         },
       ) {
         const firstNode = path.node.body[0] || {}
@@ -22,28 +20,24 @@ function codegenPlugin(babel) {
 
         if (isCodegen) {
           comments.find(isCodegenComment).value = ' this file was codegened'
-          asProgram(path, filename, parserOpts)
+          asProgram(path, fileOpts)
         }
       },
       Identifier(
         path,
         {
-          file: {
-            opts: {filename, parserOpts},
-          },
+          file: {opts: fileOpts},
         },
       ) {
         const isCodegen = path.node.name === 'codegen'
         if (isCodegen) {
-          asIdentifier(path, filename, parserOpts)
+          asIdentifier(path, fileOpts)
         }
       },
       ImportDeclaration(
         path,
         {
-          file: {
-            opts: {filename, parserOpts},
-          },
+          file: {opts: fileOpts},
         },
       ) {
         const isCodegen = looksLike(path, {
@@ -56,7 +50,7 @@ function codegenPlugin(babel) {
           },
         })
         if (isCodegen) {
-          asImportDeclaration(path, filename, parserOpts)
+          asImportDeclaration(path, fileOpts)
         }
       },
     },

--- a/src/macro.js
+++ b/src/macro.js
@@ -6,9 +6,9 @@ module.exports = createMacro(codegenMacros)
 
 function codegenMacros({references, state, babel}) {
   const {asIdentifier} = getReplacers(babel)
-  const filename = state.file.opts.filename
+  const fileOpts = state.file.opts
   references.default.forEach(referencePath => {
-    if (asIdentifier(referencePath, filename) === false) {
+    if (asIdentifier(referencePath, fileOpts) === false) {
       throw referencePath.buildCodeFrameError(
         'codegen macro must be used as a tagged template literal, function, jsx, or .require call',
         Error,

--- a/src/macro.js
+++ b/src/macro.js
@@ -1,10 +1,11 @@
 // const printAST = require('ast-pretty-print')
 const {createMacro} = require('babel-plugin-macros')
-const {asIdentifier} = require('./replace')
+const getReplacers = require('./replace')
 
 module.exports = createMacro(codegenMacros)
 
-function codegenMacros({references, state}) {
+function codegenMacros({references, state, babel}) {
+  const {asIdentifier} = getReplacers(babel)
   const filename = state.file.opts.filename
   references.default.forEach(referencePath => {
     if (asIdentifier(referencePath, filename) === false) {

--- a/src/replace.js
+++ b/src/replace.js
@@ -37,7 +37,7 @@ function asImportDeclaration(path, filename) {
     string: `
       try {
         // allow for transpilation of required modules
-        require('babel-register')
+        require('@babel/register')
       } catch (e) {
         // ignore error
       }

--- a/src/replace.js
+++ b/src/replace.js
@@ -5,135 +5,142 @@ const {
   stringToAST,
   isCodegenComment,
   isPropertyCall,
+  applyReplacementToPath,
 } = require('./helpers')
 
-module.exports = {
-  asTag,
-  asJSX,
-  asFunction,
-  asProgram,
-  asImportCall,
-  asImportDeclaration,
-  asIdentifier,
-}
+module.exports = getReplacers
 
-function asProgram(transformFromAst, path, filename) {
-  const {code: string} = transformFromAst(path.node)
-  const replacement = getReplacement({string, filename})
-  path.node.body = Array.isArray(replacement) ? replacement : [replacement]
-}
-
-function asImportDeclaration(path, filename) {
-  const codegenComment = path.node.source.leadingComments
-    .find(isCodegenComment)
-    .value.trim()
-  let args
-  if (codegenComment !== 'codegen') {
-    args = codegenComment.replace(/codegen\((.*)\)/, '$1').trim()
+function getReplacers(babel) {
+  function asProgram(path, filename) {
+    const {code: string} = babel.transformFromAst(path.node)
+    const replacement = getReplacement({string, filename}, babel)
+    path.node.body = Array.isArray(replacement) ? replacement : [replacement]
   }
 
-  replace({
-    path,
-    string: `
-      try {
-        // allow for transpilation of required modules
-        require('@babel/register')
-      } catch (e) {
-        // ignore error
-      }
-      var mod = require('${path.node.source.value}');
-      mod = mod && mod.__esModule ? mod.default : mod
-      ${args ? `mod = mod(${args})` : ''}
-      module.exports = mod
-    `,
-    filename,
-  })
-}
-
-function asIdentifier(path, filename) {
-  const targetPath = path.parentPath
-  switch (targetPath.type) {
-    case 'TaggedTemplateExpression': {
-      return asTag(targetPath, filename)
+  function asImportDeclaration(path, filename) {
+    const codegenComment = path.node.source.leadingComments
+      .find(isCodegenComment)
+      .value.trim()
+    let args
+    if (codegenComment !== 'codegen') {
+      args = codegenComment.replace(/codegen\((.*)\)/, '$1').trim()
     }
-    case 'CallExpression': {
-      const isCallee = targetPath.get('callee') === path
-      if (isCallee) {
-        return asFunction(targetPath, filename)
-      } else {
-        return false
-      }
-    }
-    case 'JSXOpeningElement': {
-      const jsxElement = targetPath.parentPath
-      return asJSX(jsxElement, filename)
-    }
-    case 'JSXClosingElement': {
-      // ignore the closing element
-      // but don't mark as unhandled (return false)
-      // we already handled the opening element
-      return true
-    }
-    case 'MemberExpression': {
-      const callPath = targetPath.parentPath
-      const isRequireCall = isPropertyCall(callPath, 'require')
-      if (isRequireCall) {
-        return asImportCall(callPath, filename)
-      } else {
-        return false
-      }
-    }
-    default: {
-      return false
-    }
-  }
-}
-
-function asImportCall(path, filename) {
-  const [source, ...args] = path.get('arguments')
-  const string = resolveModuleToString({args, filename, source})
-  const replacement = stringToAST(string)
-  if (!replacement) {
-    path.remove()
-  } else if (Array.isArray(replacement)) {
-    path.replaceWithMultiple(replacement)
-  } else {
-    path.replaceWith(replacement)
-  }
-}
-
-function asTag(path, filename) {
-  const string = path.get('quasi').evaluate().value
-  if (!string) {
-    throw path.buildCodeFrameError(
-      'Unable to determine the value of your codegen string',
-      Error,
+    replace(
+      {
+        path,
+        string: `
+          try {
+            // allow for transpilation of required modules
+            require('@babel/register')
+          } catch (e) {
+            // ignore error
+          }
+          var mod = require('${path.node.source.value}');
+          mod = mod && mod.__esModule ? mod.default : mod
+          ${args ? `mod = mod(${args})` : ''}
+          module.exports = mod
+      `,
+        filename,
+      },
+      babel,
     )
   }
-  replace({path, string, filename})
-}
 
-function asFunction(path, filename) {
-  const argumentsPaths = path.get('arguments')
-  const string = argumentsPaths[0].evaluate().value
-  replace({
-    path: argumentsPaths[0].parentPath,
-    string,
-    filename,
-  })
-}
-
-function asJSX(path, filename) {
-  const children = path.get('children')
-  let string = children[0].node.expression.value
-  if (children[0].node.expression.type === 'TemplateLiteral') {
-    string = children[0].get('expression').evaluate().value
+  function asIdentifier(path, filename) {
+    const targetPath = path.parentPath
+    switch (targetPath.type) {
+      case 'TaggedTemplateExpression': {
+        return asTag(targetPath, filename)
+      }
+      case 'CallExpression': {
+        const isCallee = targetPath.get('callee') === path
+        if (isCallee) {
+          return asFunction(targetPath, filename)
+        } else {
+          return false
+        }
+      }
+      case 'JSXOpeningElement': {
+        const jsxElement = targetPath.parentPath
+        return asJSX(jsxElement, filename)
+      }
+      case 'JSXClosingElement': {
+        // ignore the closing element
+        // but don't mark as unhandled (return false)
+        // we already handled the opening element
+        return true
+      }
+      case 'MemberExpression': {
+        const callPath = targetPath.parentPath
+        const isRequireCall = isPropertyCall(callPath, 'require')
+        if (isRequireCall) {
+          return asImportCall(callPath, filename)
+        } else {
+          return false
+        }
+      }
+      default: {
+        return false
+      }
+    }
   }
-  replace({
-    path: children[0].parentPath,
-    string,
-    filename,
-  })
+
+  function asImportCall(path, filename) {
+    const [source, ...args] = path.get('arguments')
+    const string = resolveModuleToString({args, filename, source})
+    const replacement = stringToAST(string, babel)
+    applyReplacementToPath(replacement, path)
+  }
+
+  function asTag(path, filename) {
+    const string = path.get('quasi').evaluate().value
+    if (!string) {
+      throw path.buildCodeFrameError(
+        'Unable to determine the value of your codegen string',
+        Error,
+      )
+    }
+    replace({path, string, filename}, babel)
+  }
+
+  function asFunction(path, filename) {
+    const argumentsPaths = path.get('arguments')
+    const string = argumentsPaths[0].evaluate().value
+    replace(
+      {
+        path: argumentsPaths[0].parentPath,
+        string,
+        filename,
+      },
+      babel,
+    )
+  }
+
+  function asJSX(path, filename) {
+    const children = path.get('children')
+    let string = children[0].node.expression.value
+    if (children[0].node.expression.type === 'TemplateLiteral') {
+      string = children[0].get('expression').evaluate().value
+    }
+    replace(
+      {
+        path: children[0].parentPath,
+        string,
+        filename,
+      },
+      babel,
+    )
+  }
+
+  return {
+    asTag,
+    asJSX,
+    asFunction,
+    asProgram,
+    asImportCall,
+    asImportDeclaration,
+    asIdentifier,
+  }
 }
 
 /*


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Hey Kent 👋

Maybe you have a minute to share your thoughts about this. ;)

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Actually I'm doing two things at once here, let me know if i shall issue two pull requests.

1. Adding parser-plugins to the AST generation to allow dynamicImport and objectRestSpread. 
2. Upgrading babel to version 7 beta (`@babel/`-releases).

I'm not quite sure if applying 2. here is the correct upgrade path.

<!-- Why are these changes necessary? -->
**Why**:

1. This fixes #9. And allows for more stuff to be done in codegen'd code. Maybe it makes sense to consider adding more plugins here (or make if configurable?) - I'm not quite sure how to decide.
2. This makes it possible to use codegen with newer versions of babel.

<!-- How were these changes implemented? -->
**How**:

1. Adding parser-plugins to AST generation.
2. Updated stuff in package.json…

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Cheers! Jan.