### PR TITLE
fix: fix invalid code when using a single import/export declaration

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -75,8 +75,7 @@ codegen\`module.exports = "var ALLCAPS = 'ALLCAPS'"\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var ALLCAPS
-;(ALLCAPS = 'ALLCAPS'), void 0
+var ALLCAPS = 'ALLCAPS'
 
 
 `;
@@ -335,8 +334,7 @@ codegen\`module.exports = "var x = 'some directive'"\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var x
-;(x = 'some directive'), void 0
+var x = 'some directive'
 
 
 `;

--- a/src/__tests__/__snapshots__/macro.js.snap
+++ b/src/__tests__/__snapshots__/macro.js.snap
@@ -9,13 +9,11 @@ myCodgen(\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var x
-;(x = {
+var x = {
   booyah() {
     return 'booyah!'
   },
-}),
-  void 0
+}
 
 
 `;
@@ -99,6 +97,32 @@ Error: <PROJECT_ROOT>/src/__tests__/macro.js: ../macro: codegen macro must be us
   1 | import codegen from '../macro';
 > 2 | var x = codegen;
     |         ^^^^^^^
+
+`;
+
+exports[`macros with a single export declaration: with a single export declaration 1`] = `
+
+import codegen from '../macro'
+
+codegen\`module.exports = "export const a = 'a'"\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export const a = 'a'
+
+
+`;
+
+exports[`macros with a single import declaration: with a single import declaration 1`] = `
+
+import codegen from '../macro'
+
+codegen\`module.exports = "import a from 'a'"\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import a from 'a'
+
 
 `;
 

--- a/src/__tests__/macro.js
+++ b/src/__tests__/macro.js
@@ -49,6 +49,16 @@ pluginTester({
 
       codegen\`module.exports = ['a', 'b', 'c'].map(l => 'export const ' + l + ' = ' + JSON.stringify(l)).join(';')\`
     `,
+    'with a single export declaration': `
+      import codegen from '../macro'
+
+      codegen\`module.exports = "export const a = 'a'"\`
+    `,
+    'with a single import declaration': `
+      import codegen from '../macro'
+
+      codegen\`module.exports = "import a from 'a'"\`
+    `,
     'as require call': `
       import codegen from '../macro';
       var x = codegen.require('./fixtures/return-one');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,12 +49,15 @@ function getReplacement({code, fileOpts, args = []}, babel) {
 }
 
 function applyReplacementToPath(replacement, path) {
-  if (!replacement) {
-    path.remove()
-  } else if (Array.isArray(replacement)) {
-    path.replaceWithMultiple(replacement)
+  if (replacement) {
+    // If it's not an array, wrap into an array
+    // to support single import/export declarations:
+    // https://github.com/kentcdodds/babel-plugin-codegen/issues/30
+    path.replaceWithMultiple(
+      Array.isArray(replacement) ? replacement : [replacement],
+    )
   } else {
-    path.replaceWith(replacement)
+    path.remove()
   }
 }
 


### PR DESCRIPTION
Fixes #30

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: avoid wrapping top-level statements such as `import`/`export` declarations in an IIFE.

<!-- Why are these changes necessary? -->

**Why**: wrapping top-level statements in an IIFE results in invalid code.

<!-- How were these changes implemented? -->

**How**: Always use `path.replaceWithMultiple(replacement)` instead of `path.replaceWith(replacement)` and wrap `replacement` into an array if it's not an array already because `path.replaceWith(replacement)` sometimes wraps replacements in an IIFE leading to invalid code, e.g. if you try to use an `import` or `export` declaration.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
