### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,14 @@ var x = 3
 **Before**:
 
 ```javascript
-const x = codegen.require('./es6-identity', 3)
+codegen.require('./es6-identity', 3)
 ```
 
 **After** (`es6-identity.js` is:
 `export default input => 'var x = ' + JSON.stringify(input) + ';'`):
 
 ```javascript
-const x = 3
+var x = 3
 ```
 
 ### codegen file comment (`// @codegen`)


### PR DESCRIPTION
Tested this locally  ["@babel/cli": "^7.14.8", "@babel/core": "^7.15.0", "babel-plugin-codegen": "^4.1.4"]

```javascript
const x = codegen.require('./es6-identity', 3)
```

where es6-identity.js is:

```javascript
export default input => 'var x = ' + JSON.stringify(input) + ';'
```

Results in a transpilation error: `Duplicate declaration "x"`
