### PR TITLE
Remove anti linter comments, and correct functions

### DIFF
--- a/src/replace.ts
+++ b/src/replace.ts
@@ -15,7 +15,7 @@ function getReplacers(babel: typeof babelCore) {
     fileOpts: babelCore.TransformOptions,
   ) {
 
-    const result = babel.transformFromAstSync(path.node, undefined, {
+    const result = babel.transformFromAstSync(path.node, path.getSource(), {
       filename: fileOpts.filename,
       plugins: fileOpts.plugins,
       presets: fileOpts.presets,

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -14,8 +14,8 @@ function getReplacers(babel: typeof babelCore) {
     path: babelCore.NodePath<babelCore.types.Program>,
     fileOpts: babelCore.TransformOptions,
   ) {
-    // @ts-expect-error the types for this is wrong...
-    const result = babel.transformFromAstSync(path.node, {
+
+    const result = babel.transformFromAstSync(path.node, undefined, {
       filename: fileOpts.filename,
       plugins: fileOpts.plugins,
       presets: fileOpts.presets,
@@ -106,7 +106,7 @@ function getReplacers(babel: typeof babelCore) {
         return true
       }
       case 'MemberExpression': {
-        const callPath = targetPath.parentPath
+        const callPath = (targetPath as babelCore.NodePath<babelCore.types.MemberExpression>).parentPath
         const isRequireCall = isPropertyCall(callPath, 'require')
         if (isRequireCall) {
           return asImportCall(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Remove anti linter comments, and correct functions

[https://github.com/kentcdodds/babel-plugin-codegen/issues/40](https://github.com/kentcdodds/babel-plugin-codegen/issues/40)

[https://github.com/kentcdodds/babel-plugin-codegen/issues/18](https://github.com/kentcdodds/babel-plugin-codegen/issues/18)

<!-- Why are these changes necessary? -->

**Why**: 
[https://babeljs.io/docs/en/babel-core#transformfromastsync](https://babeljs.io/docs/en/babel-core#transformfromastsync)
> babel.transformFromAstSync(ast: Object, code?: string, options?: Object)

Current code base using
```ts
    // @ts-expect-error the types for this is wrong...
    const result = babel.transformFromAstSync(path.node, {
      filename: fileOpts.filename,
      plugins: fileOpts.plugins,
      presets: fileOpts.presets,
    })
```

<!-- How were these changes implemented? -->

**How**: Remove anti linter magic comments, and correct functions

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
