### PR TITLE
Support importing npm modules by name

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -106,8 +106,8 @@ function resolveModuleContents({
   filename: string
   module: string
 }) {
-  const resolvedPath = p.resolve(p.dirname(filename), module)
-  const code = fs.readFileSync(require.resolve(resolvedPath))
+  const resolvedPath = require.resolve(module, { paths: [p.dirname(filename)] })
+  const code = fs.readFileSync(resolvedPath);
   return {code, resolvedPath}
 }
 


### PR DESCRIPTION
**What**:

Adds support for `codegen.require('module-name')` to load and codegen the main export of an npm module. Fixes #47.

**Why**:

I've created a reusable codegen which works great. However, once I published & consume the codegen as an [npm module (`@ceteio/next-layout-loader`)](https://github.com/ceteio/next-layout-loader), it no longer works. More details in #47.

**How**:

Node's built-in `require.resolve` algorithm supports both relative paths, and module name specifiers. The [second argument to `require.resolve`](https://nodejs.org/api/modules.html#requireresolverequest-options) allows specifying where to begin the search, which mirrors the existing behaviour, but adds the ability to load modules from `node_modules` up the tree (should even work in monorepos!).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] ~Documentation~ n/a
- [ ] Tests. ?? How would I test this?
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
